### PR TITLE
[!!!][TASK] Rename database fields and table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog 
+
+This extension is still in beta. While we are using it in testing and production environments, there are still things
+that might change as feedback and experiences from real-life use cases come in. Here's a list of recent breaking
+changes.
+
+## Version 0.2.0
+
+### Renaming of database tables and fields
+
+Database fields and tables have been renamed to comply with 
+[TYPO3 best practices](https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/NamingConventions/Index.html#database-table-name).
+
+* The default database field for holding a list for content elements has been renamed to `tx_listelements_list`.
+* The database table for list items has been renamed to `tx_listelements_item`.
+* LLL-keys have updated identifiers according to new field names/table names.
+
+After updating, make sure to update your project files as follows:
+
+#### Update database
+
+*After* adding new fields and tables to your database using the install tool/TYPO3 console, prepare a database backup 
+just in case. Assuming the table `tx_listelements_item` is empty, run the following commands:
+
+```
+# remove empty new table
+DROP TABLE tx_listelements_item;
+# rename old listitems table
+ALTER TABLE listitems RENAME TO tx_listelements_item;
+
+# update references 
+UPDATE tt_content SET tx_listelements_list = list WHERE list != '';
+UPDATE tx_listelements_item SET fieldname = 'tx_listelements_list' WHERE fieldname = 'list';
+UPDATE sys_file_reference SET tablenames = 'tx_listelements_item' WHERE tablenames = 'listitems';
+
+# rename/update references due to changed fieldname "images" (instead of "image")
+UPDATE tx_listelements_item SET images = image;
+UPDATE sys_file_reference SET fieldname = "images" WHERE fieldname="image" and tablenames = "tx_listelements_item";
+```
+
+#### Update your TCA of custom elements created
+
+* Update all references for content elements using the old field `list` to now use `tx_listelements_list`. This also 
+  applies to palettes created.
+* Update custom fields added to the table `listelements` to now be added to `tx_listelements_list`.
+* Update references to LLL labels taken from `EXT:listelements` (if you re-used labels in your TCA/PageTSConfig).
+* Update all references to field `image` of listelements, this field has been renamed to `images` to be more precise 
+  (and in line with `assets`).\
+  Note that this also applies to all `showitem` configurations as well as `columnsOverrides` 
+  configuration.
+  
+#### Update backend preview templates
+
+The arrays for images and assets file references have been renamed 
+* from `allAssets` to `processedAssets`
+* from `allImage` to `processedImages`
+Update your Fluid templates accordingly.
+

--- a/Classes/Hooks/DrawItem.php
+++ b/Classes/Hooks/DrawItem.php
@@ -14,7 +14,7 @@ use TYPO3\CMS\Backend\View\PageLayoutViewDrawItemHookInterface;
 use TYPO3\CMS\Backend\View\PageLayoutView;
 
 /**
- * Class/Function to manipulates the rendering of item example content
+ * Class/Function to manipulate the rendering of item preview content
  *
  */
 class DrawItem implements PageLayoutViewDrawItemHookInterface
@@ -32,10 +32,10 @@ class DrawItem implements PageLayoutViewDrawItemHookInterface
         &$drawItem,
         &$headerContent,
         &$itemContent,
-        &$row
+        array &$row
     ) {
         // get all list items including all assets
-        if ($row['list']) {
+        if ($row['tx_listelements_list']) {
             \B13\Listelements\Service\ListService::resolveListitems($row);
         }
     }

--- a/Classes/Service/ListService.php
+++ b/Classes/Service/ListService.php
@@ -26,22 +26,22 @@ class ListService
      * @param string $filereferences: comma separated list of fields with file references
      *
      */
-    public static function resolveListitems(array &$row, $field = 'list', $table = 'tt_content', $filereferences = 'assets,image')
+    public static function resolveListitems(array &$row, $field = 'tx_listelements_list', $table = 'tt_content', $filereferences = 'assets,images')
     {
         $returnAs = 'listitems_' . $field;
-        if ($returnAs === 'listitems_list') {
+        if ($returnAs === 'listitems_tx_listelements_list') {
             $returnAs = 'listitems';
         }
 
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('listitems');
+            ->getQueryBuilderForTable('tx_listelements_item');
         $queryBuilder->getRestrictions()
             ->removeAll()
             ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
             ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, (int)$GLOBALS['BE_USER']->workspace));
         $queryBuilder
             ->select('*')
-            ->from('listitems')
+            ->from('tx_listelements_item')
             ->orderBy('sorting_foreign')
             ->where(
                 $queryBuilder->expr()->eq('uid_foreign', $row['uid'])
@@ -71,9 +71,9 @@ class ListService
             foreach(explode(',', $filereferences) as $fieldname) {
                 $fieldname = trim($fieldname);
                 if($item[$fieldname]) {
-                    $row[$returnAs][$key]['all' . ucfirst($fieldname)] = \B13\Listelements\Service\FilereferenceService::resolveFilereferences(
+                    $row[$returnAs][$key]['processed' . ucfirst($fieldname)] = \B13\Listelements\Service\FilereferenceService::resolveFilereferences(
                         $fieldname,
-                        'listitems',
+                        'tx_listelements_item',
                         $item['uid']);
                 }
             }

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -6,11 +6,11 @@ defined('TYPO3_MODE') or die();
  */
 $additionalColumns = [
 	// add field for saving the list of elements for a list or a slider
-	'list' => [
+	'tx_listelements_list' => [
 		'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tt_content.list',
 		'config' => [
 			'type' => 'inline',
-			'foreign_table' => 'listitems',
+			'foreign_table' => 'tx_listelements_item',
 			'foreign_field' => 'uid_foreign',
 			'appearance' => [
                 'showSynchronizationLink' => FALSE,

--- a/Configuration/TCA/tx_listelements_item.php
+++ b/Configuration/TCA/tx_listelements_item.php
@@ -2,7 +2,7 @@
 
 return [
     'ctrl' => [
-        'title' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.title',
+        'title' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.title',
         'label' => 'header',
         'label_alt' => 'subheader,bodytext,text,linklabel',
         'label_alt_force' => 1,
@@ -66,8 +66,8 @@ return [
                 'items' => [
                     ['', 0],
                 ],
-                'foreign_table' => 'listitems',
-                'foreign_table_where' => 'AND listitems.uid=###REC_FIELD_l10n_parent### AND listitems.sys_language_uid IN (-1,0)',
+                'foreign_table' => 'tx_listelements_item',
+                'foreign_table_where' => 'AND tx_listelements_item.uid=###REC_FIELD_l10n_parent### AND tx_listelements_item.sys_language_uid IN (-1,0)',
                 'default' => 0,
             ],
         ],
@@ -90,7 +90,7 @@ return [
             ],
         ],
         'uid_foreign' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.title',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.title',
             'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
@@ -101,7 +101,7 @@ return [
             ],
         ],
         'sorting_foreign' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.sorting_foreign',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.sorting_foreign',
             'config' => [
                 'type' => 'input',
                 'size' => 4,
@@ -116,7 +116,7 @@ return [
             ],
         ],
         'tablename' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_tca.xlf:listitems.tablename',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_tca.xlf:tx_listelements_item.tablename',
             'l10n_mode' => 'exclude',
             'config' => [
                 'type' => 'input',
@@ -125,7 +125,7 @@ return [
             ]
         ],
         'fieldname' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_tca.xlf:listitems.fieldname',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_tca.xlf:tx_listelements_item.fieldname',
             'l10n_mode' => 'exclude',
             'config' => [
                 'type' => 'input',
@@ -136,7 +136,7 @@ return [
         'header' => [
             'l10n_mode' => 'prefixLangTitle',
             'l10n_cat' => 'text',
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.header',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.header',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -144,7 +144,7 @@ return [
             ],
         ],
         'subheader' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.subheader',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.subheader',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -153,7 +153,7 @@ return [
             ],
         ],
         'layout' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.layout',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.layout',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
@@ -162,7 +162,7 @@ return [
         ],
         'text' => [
             'l10n_mode' => 'prefixLangTitle',
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.text',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.text',
             'config' => [
                 'type' => 'text',
                 'cols' => 80,
@@ -172,7 +172,7 @@ return [
         ],
         'bodytext' => [
             'l10n_mode' => 'prefixLangTitle',
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.bodytext',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.bodytext',
             'config' => [
                 'type' => 'text',
                 'cols' => 80,
@@ -181,13 +181,13 @@ return [
                 'enableRichtext' => true
             ]
         ],
-        'image' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.image',
+        'images' => [
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.images',
             'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
-                'image',
+                'images',
                 [
                     'appearance' => [
-                        'createNewRelationLinkTitle' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.image.addFileReference',
+                        'createNewRelationLinkTitle' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.images.addFileReference',
                     ],
                     // custom configuration for displaying fields in the overlay/reference table
                     // to use the imageoverlayPalette instead of the basicoverlayPalette
@@ -232,12 +232,12 @@ return [
             ),
         ],
         'assets' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.assets',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.assets',
             'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
                 'assets',
                 [
                     'appearance' => [
-                        'createNewRelationLinkTitle' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.assets.addFileReference',
+                        'createNewRelationLinkTitle' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.assets.addFileReference',
                     ],
                     // custom configuration for displaying fields in the overlay/reference table
                     // to use the imageoverlayPalette instead of the basicoverlayPalette
@@ -282,7 +282,7 @@ return [
             ),
         ],
         'link' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.link',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.link',
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputLink',
@@ -291,14 +291,14 @@ return [
                 'eval' => 'trim',
                 'fieldControl' => [
                     'linkPopup' => [
-                        'title' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.link',
+                        'title' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.link',
                     ],
                 ],
                 'softref' => 'typolink',
             ],
         ],
         'linklabel' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.linklabel',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.linklabel',
             'config' => [
                 'type' => 'input',
                 'size' => 50,
@@ -306,7 +306,7 @@ return [
             ],
         ],
         'linkconfig' => [
-            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:listitems.linkconfig',
+            'label' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.linkconfig',
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -2,8 +2,8 @@
 lib.contentElement {
 	dataProcessing.1421884800 = TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor
 	dataProcessing.1421884800 {
-		if.isTrue.field = list
-		table = listitems
+		if.isTrue.field = tx_listelements_list
+		table = tx_listelements_item
 		colPos.data = field:colPos
 		pidInList.data = field:pid
 		orderBy = sorting_foreign
@@ -17,15 +17,15 @@ lib.contentElement {
 			10 {
 				if.isTrue.field = assets
 				references.fieldName = assets
-				references.table = listitems
+				references.table = tx_listelements_item
 				sorting = sorting_foreign
 				as = listassets
 			}
 			21 = TYPO3\CMS\Frontend\DataProcessing\FilesProcessor
 			21 {
-				if.isTrue.field = image
-				references.fieldName = image
-				references.table = listitems
+				if.isTrue.field = images
+				references.fieldName = images
+				references.table = tx_listelements_item
 				sorting = sorting_foreign
 				as = listimages
 			}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## About this extension
 
-This extension adds list items to tt_content. It adds a database field `list` to `tt_content` that allows adding
-flexible list items as IRRE records to any content element.
+This extension adds list items to tt_content. It adds a database field `tx_listelements_list` to `tt_content` that 
+allows adding flexible list items as IRRE records to any content element.
 
 ## Installation
 
@@ -39,7 +39,7 @@ use TYPO3\CMS\Backend\View\PageLayoutViewDrawItemHookInterface;
 use TYPO3\CMS\Backend\View\PageLayoutView;
 
 /**
- * Class/Function which manipulates the rendering of item example content
+ * Class/Function to manipulate the rendering of item preview content
  *
  */
 class DrawItem implements PageLayoutViewDrawItemHookInterface

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -15,75 +15,75 @@
 				<source>Add Item</source>
 				<target>Eintrag hinzufügen</target>
 			</trans-unit>
-			<trans-unit id="listitems.title">
+			<trans-unit id="tx_listelements_item.title">
 				<source>Listitem</source>
 				<target>Listeneinträge</target>
 			</trans-unit>
-			<trans-unit id="listitems.sorting_foreign">
+			<trans-unit id="tx_listelements_item.sorting_foreign">
 				<source>Sorting</source>
 				<target>Sortierung</target>
 			</trans-unit>
-			<trans-unit id="listitems.tablename">
+			<trans-unit id="tx_listelements_item.tablename">
 				<source>Reference database table</source>
 				<target>Verknüpfung: Datenbanktabelle</target>
 			</trans-unit>
-			<trans-unit id="listitems.fieldname">
+			<trans-unit id="tx_listelements_item.fieldname">
 				<source>Reference database field</source>
 				<target>Verknüpfung: Datenbankfeld</target>
 			</trans-unit>
-			<trans-unit id="listitems.header">
+			<trans-unit id="tx_listelements_item.header">
 				<source>Header</source>
 				<target>Überschrift</target>
 			</trans-unit>
-			<trans-unit id="listitems.subheader">
+			<trans-unit id="tx_listelements_item.subheader">
 				<source>Subheader</source>
 				<target>Subheader</target>
 			</trans-unit>
-			<trans-unit id="listitems.layout">
+			<trans-unit id="tx_listelements_item.layout">
 				<source>Layout</source>
 				<target>Layout</target>
 			</trans-unit>
-			<trans-unit id="listitems.text" res_name="listitems.text">
+			<trans-unit id="tx_listelements_item.text" res_name="tx_listelements_item.text">
 				<source>Text</source>
 				<target>Text</target>
 			</trans-unit>
-			<trans-unit id="listitems.bodytext">
+			<trans-unit id="tx_listelements_item.bodytext">
 				<source>Text</source>
 				<target>Text</target>
 			</trans-unit>
-			<trans-unit id="listitems.uid_foreign">
+			<trans-unit id="tx_listelements_item.uid_foreign">
 				<source>Foreign Table Element Reference</source>
 				<target>Tabelle Referenz</target>
 			</trans-unit>
-			<trans-unit id="listitems.assets">
+			<trans-unit id="tx_listelements_item.assets">
 				<source>Media Assets</source>
 				<target>Medien</target>
 			</trans-unit>
-			<trans-unit id="listitems.assets.addFileReference">
+			<trans-unit id="tx_listelements_item.assets.addFileReference">
 				<source>Add Media</source>
 				<target>Medien hinzufügen</target>
 			</trans-unit>
-			<trans-unit id="listitems.image">
+			<trans-unit id="tx_listelements_item.images">
 				<source>Images</source>
 				<target>Bilder</target>
 			</trans-unit>
-			<trans-unit id="listitems.image.addFileReference">
+			<trans-unit id="tx_listelements_item.images.addFileReference">
 				<source>Add Image</source>
 				<target>Bild hinzufügen</target>
 			</trans-unit>
-			<trans-unit id="listitems.link">
+			<trans-unit id="tx_listelements_item.link">
 				<source>Link</source>
 				<target>Link</target>
 			</trans-unit>
-			<trans-unit id="listitems.linklabel">
+			<trans-unit id="tx_listelements_item.linklabel">
 				<source>Label for Link</source>
 				<target>Linktext</target>
 			</trans-unit>
-			<trans-unit id="listitems.linkconfig">
+			<trans-unit id="tx_listelements_item.linkconfig">
 				<source>Type/Configuration of Link</source>
 				<target>Konfiguration für Link</target>
 			</trans-unit>
-            <trans-unit id="listitems.linkconfig.I.0">
+            <trans-unit id="tx_listelements_item.linkconfig.I.0">
                 <source>Default</source>
                 <target>Standard</target>
             </trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -13,58 +13,58 @@
 			<trans-unit id="tt_content.list.newRecordLinkAddTitle">
 				<source>Add Item</source>
 			</trans-unit>
-			<trans-unit id="listitems.title">
+			<trans-unit id="tx_listelements_item.title">
 				<source>Listitem</source>
 			</trans-unit>
-			<trans-unit id="listitems.sorting_foreign">
+			<trans-unit id="tx_listelements_item.sorting_foreign">
 				<source>Sorting</source>
 			</trans-unit>
-			<trans-unit id="listitems.tablename">
+			<trans-unit id="tx_listelements_item.tablename">
 				<source>Reference database table</source>
 			</trans-unit>
-			<trans-unit id="listitems.fieldname">
+			<trans-unit id="tx_listelements_item.fieldname">
 				<source>Reference database field</source>
 			</trans-unit>
-			<trans-unit id="listitems.header">
+			<trans-unit id="tx_listelements_item.header">
 				<source>Header</source>
 			</trans-unit>
-			<trans-unit id="listitems.subheader">
+			<trans-unit id="tx_listelements_item.subheader">
 				<source>Subheader</source>
 			</trans-unit>
-			<trans-unit id="listitems.layout">
+			<trans-unit id="tx_listelements_item.layout">
 				<source>Layout</source>
 			</trans-unit>
-			<trans-unit id="listitems.text" res_name="listitems.text">
+			<trans-unit id="tx_listelements_item.text" res_name="tx_listelements_item.text">
 				<source>Text</source>
 			</trans-unit>
-			<trans-unit id="listitems.bodytext">
+			<trans-unit id="tx_listelements_item.bodytext">
 				<source>Text</source>
 			</trans-unit>
-			<trans-unit id="listitems.uid_foreign">
+			<trans-unit id="tx_listelements_item.uid_foreign">
 				<source>Foreign Table Element Reference</source>
 			</trans-unit>
-			<trans-unit id="listitems.assets">
+			<trans-unit id="tx_listelements_item.assets">
 				<source>Media Assets</source>
 			</trans-unit>
-			<trans-unit id="listitems.assets.addFileReference">
+			<trans-unit id="tx_listelements_item.assets.addFileReference">
 				<source>Add Media</source>
 			</trans-unit>
-			<trans-unit id="listitems.image">
+			<trans-unit id="tx_listelements_item.images">
 				<source>Images</source>
 			</trans-unit>
-			<trans-unit id="listitems.image.addFileReference">
+			<trans-unit id="tx_listelements_item.images.addFileReference">
 				<source>Add Image</source>
 			</trans-unit>
-			<trans-unit id="listitems.link">
+			<trans-unit id="tx_listelements_item.link">
 				<source>Link</source>
 			</trans-unit>
-			<trans-unit id="listitems.linklabel">
+			<trans-unit id="tx_listelements_item.linklabel">
 				<source>Label for Link</source>
 			</trans-unit>
-			<trans-unit id="listitems.linkconfig">
+			<trans-unit id="tx_listelements_item.linkconfig">
 				<source>Type/Configuration of Link</source>
 			</trans-unit>
-			<trans-unit id="listitems.linkconfig.I.0">
+			<trans-unit id="tx_listelements_item.linkconfig.I.0">
 				<source>Default</source>
 			</trans-unit>
 		</body>

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -3,5 +3,5 @@
 defined('TYPO3_MODE') or die('Access denied.');
 
 (function () {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('listitems');
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_listelements_item');
 })();

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -2,13 +2,13 @@
 # Table structure for table 'tt_content'
 #
 CREATE TABLE tt_content (
-	list text
+	tx_listelements_list int(4) DEFAULT '0' NOT NULL
 );
 
 #
-# Table structure for table 'listitems'
+# Table structure for table 'tx_listelements_item'
 #
-CREATE TABLE listitems (
+CREATE TABLE tx_listelements_item (
 
 # Reference fields (basically same as MM table)
 	sorting_foreign int(11) DEFAULT '0' NOT NULL,
@@ -16,13 +16,13 @@ CREATE TABLE listitems (
 
 # local usage fields
 	tablename varchar(64) DEFAULT 'tt_content' NOT NULL,
-	fieldname varchar(64) DEFAULT 'list' NOT NULL,
+	fieldname varchar(64) DEFAULT 'tx_listelements_list' NOT NULL,
 	header varchar(255) DEFAULT '' NOT NULL,
 	subheader varchar(255) DEFAULT '' NOT NULL,
 	layout varchar(255) DEFAULT '' NOT NULL,
 	text mediumtext,
 	bodytext mediumtext,
-	image int(11) unsigned DEFAULT '0' NOT NULL,
+	images int(11) unsigned DEFAULT '0' NOT NULL,
 	assets int(11) unsigned DEFAULT '0' NOT NULL,
 	link varchar(1024) DEFAULT '' NOT NULL,
 	linklabel varchar(255) DEFAULT '' NOT NULL,


### PR DESCRIPTION
To comply with best practices this commit changes database table and field names according to https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/NamingConventions/Index.html#database-table-name

Related: BEXT-251