### PR TITLE
[BUGFIX] Workspace sorting

### DIFF
--- a/Classes/DataProcessing/ListItemsDataProcessor.php
+++ b/Classes/DataProcessing/ListItemsDataProcessor.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B13\Listelements\DataProcessing;
+
+/*
+ * This file is part of TYPO3 CMS-extension listelements by b13.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ */
+
+use B13\Listelements\Service\ListService;
+use TYPO3\CMS\Frontend\ContentObject\DataProcessorInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentDataProcessor;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor;
+
+class ListItemsDataProcessor implements DataProcessorInterface
+{
+    protected ListService $listService;
+    protected ContentDataProcessor $contentDataProcessor;
+
+    public function __construct(ListService $listService, ContentDataProcessor $contentDataProcessor)
+    {
+        $this->listService = $listService;
+        $this->contentDataProcessor = $contentDataProcessor;
+    }
+
+    public function process(
+        ContentObjectRenderer $cObj,
+        array $contentObjectConfiguration,
+        array $processorConfiguration,
+        array $processedData
+    ): array
+    {
+        if (isset($processorConfiguration['if.']) && !$cObj->checkIf($processorConfiguration['if.'])) {
+            return $processedData;
+        }
+        $data = $cObj->data;
+        if ((int)($data['tx_listelements_list'] ?? 0) === 0) {
+            return $processedData;
+        }
+        $targetVariableName = $cObj->stdWrapValue('as', $processorConfiguration, 'listitems');
+        $items = $this->listService->resolveItemsForFrontend((int)($data['_LOCALIZED_UID'] ?? $data['uid']));
+        $request = $cObj->getRequest();
+        $processedRecordVariables = [];
+        foreach ($items as $key => $record) {
+            $recordContentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+            $recordContentObjectRenderer->start($record, 'tx_listelements_item', $request);
+            $processedRecordVariables[$key] = ['data' => $record];
+            $processedRecordVariables[$key] = $this->contentDataProcessor->process($recordContentObjectRenderer, $processorConfiguration, $processedRecordVariables[$key]);
+        }
+        $processedData[$targetVariableName] = $processedRecordVariables;
+        return $processedData;
+    }
+}

--- a/Classes/Service/ListService.php
+++ b/Classes/Service/ListService.php
@@ -14,15 +14,8 @@ namespace B13\Listelements\Service;
 
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Context\Context;
-use TYPO3\CMS\Core\Database\Connection;
-use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
-use TYPO3\CMS\Core\Database\Query\Restriction\FrontendRestrictionContainer;
-use TYPO3\CMS\Core\Database\Query\Restriction\FrontendWorkspaceRestriction;
-use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
-use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
+use TYPO3\CMS\Core\Database\RelationHandler;
 use TYPO3\CMS\Core\Domain\Repository\PageRepository;
-use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Resource\FileRepository;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -30,6 +23,9 @@ use TYPO3\CMS\Core\Versioning\VersionState;
 
 class ListService implements SingletonInterface
 {
+
+    private const TABLE = 'tx_listelements_item';
+
     /**
      * @param array $row: The current data row for this item
      * @param string $field: Fieldname used to resolve the reference
@@ -43,119 +39,69 @@ class ListService implements SingletonInterface
         if ($returnAs === 'listitems_tx_listelements_list') {
             $returnAs = 'listitems';
         }
-
-        $workspaceId = GeneralUtility::makeInstance(Context::class)->getAspect('workspace')->getId();
-
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('tx_listelements_item');
-        $queryBuilder->getRestrictions()
-            ->removeAll()
-            ->add(GeneralUtility::makeInstance(DeletedRestriction::class))
-            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $workspaceId));
-        $queryBuilder
-            ->select('*')
-            ->from('tx_listelements_item')
-            ->orderBy('sorting_foreign')
-            ->where(
-                $queryBuilder->expr()->eq(
-                    'uid_foreign',
-                    $queryBuilder->createNamedParameter($row['uid'], Connection::PARAM_INT)
-                )
-            );
-
-        $queryBuilder
-            ->andWhere(
-                $queryBuilder->expr()->eq('fieldname', $queryBuilder->createNamedParameter($field)),
-                $queryBuilder->expr()->eq('tablename', $queryBuilder->createNamedParameter($table))
-            );
-
-        $items = $queryBuilder
-            ->execute()
-            ->fetchAllAssociative();
-
-        $results = [];
-        foreach ($items as $item) {
-            BackendUtility::workspaceOL('tx_listelements_item', $item);
-            if ($item !== false && !VersionState::cast($item['t3ver_state'] ?? 0)->equals(VersionState::DELETE_PLACEHOLDER)) {
-                $results[] = $item;
-            }
-        }
-        if ($workspaceId > 0) {
-            $results = $this->resortWorkspaceRows($results);
-        }
-        $row[$returnAs] = $results;
-
-        // count the number of non-hidden list items in case we need this for a backend preview warning, error message etc.
-        // saved to $row[$returnAs . '-numberOfVisibleItems']
-        $queryBuilder->getRestrictions()
-            ->add(GeneralUtility::makeInstance(HiddenRestriction::class));
-        $queryBuilder->count('uid');
-
-        $row[$returnAs . '-numberOfVisibleItems'] = $queryBuilder
-            ->execute()
-            ->fetchOne();
-
         $fileRepository = GeneralUtility::makeInstance(FileRepository::class);
-        foreach ($row[$returnAs] as $key => $item) {
-            foreach (explode(',', $filereferences) as $fieldname) {
-                $fieldname = trim($fieldname);
-                $row[$returnAs][$key]['processed' . ucfirst($fieldname)] = $fileRepository->findByRelation('tx_listelements_item', $fieldname, $item['uid']);
+        $workspaceId = GeneralUtility::makeInstance(Context::class)->getAspect('workspace')->getId();
+        $relationHandler = GeneralUtility::makeInstance(RelationHandler::class);
+        $relationHandler->setWorkspaceId($workspaceId);
+        $relationHandler->start(
+            '',
+            self::TABLE,
+            '',
+            $row['uid'],
+            'tt_content',
+            BackendUtility::getTcaFieldConfiguration('tt_content', 'tx_listelements_list')
+        );
+        $results = $relationHandler->getFromDB();
+        $results = $results[self::TABLE] ?? [];
+        $items = [];
+        $visibleItems = 0;
+        foreach ($relationHandler->tableArray[self::TABLE] ?? [] as $uid) {
+            if (isset($results[$uid])) {
+                $item = $results[$uid];
+                BackendUtility::workspaceOL(self::TABLE, $item);
+                if ($item !== false && !VersionState::cast($item['t3ver_state'] ?? 0)->equals(VersionState::DELETE_PLACEHOLDER)) {
+                    if ((int)$item['hidden'] === 0) {
+                        $visibleItems++;
+                    }
+                    foreach (explode(',', $filereferences) as $fieldname) {
+                        $item['processed' . ucfirst($fieldname)] = $fileRepository->findByRelation(self::TABLE, $fieldname, $item['uid']);
+                    }
+                    $items[] = $item;
+                }
             }
         }
+        $row[$returnAs] = $items;
+        $row[$returnAs . '-numberOfVisibleItems'] = $visibleItems;
         return $row;
-    }
-
-    protected function resortWorkspaceRows(array $rows): array
-    {
-        $sortings = [];
-        foreach ($rows as $row) {
-            $sortings[] = $row['sorting_foreign'];
-        }
-        array_multisort($sortings, $rows, SORT_ASC, SORT_NUMERIC);
-        return $rows;
     }
 
     public function resolveItemsForFrontend(int $uid): array
     {
         $workspaceId = GeneralUtility::makeInstance(Context::class)->getAspect('workspace')->getId();
-
-        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
-            ->getQueryBuilderForTable('tx_listelements_item');
-        $queryBuilder->setRestrictions(GeneralUtility::makeInstance(FrontendRestrictionContainer::class));
-        // do not use FrontendWorkspaceRestriction
-        $queryBuilder->getRestrictions()
-            ->removeByType(FrontendWorkspaceRestriction::class)
-            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class, $workspaceId));
-        $stm = $queryBuilder
-            ->select('*')
-            ->from('tx_listelements_item')
-            ->orderBy('sorting_foreign')
-            ->where(
-                $queryBuilder->expr()->eq(
-                    'uid_foreign',
-                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)
-                ),
-                $queryBuilder->expr()->eq('fieldname', $queryBuilder->createNamedParameter('tx_listelements_list')),
-                $queryBuilder->expr()->eq('tablename', $queryBuilder->createNamedParameter('tt_content'))
-            )
-            ->execute();
-        if ((GeneralUtility::makeInstance(Typo3Version::class))->getMajorVersion() === 10) {
-            $rows = $stm->fetchAll();
-        } else {
-            $rows = $stm->fetchAllAssociative();
-        }
-        if ($workspaceId > 0) {
-            $items = [];
-            $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
-            foreach ($rows as $row) {
-                $pageRepository->versionOL('tx_listelements_item', $row, true);
-                if ($row !== false) {
-                    $items[] = $row;
+        $pageRepository = GeneralUtility::makeInstance(PageRepository::class);
+        $relationHandler = GeneralUtility::makeInstance(RelationHandler::class);
+        $relationHandler->setWorkspaceId($workspaceId);
+        $relationHandler->additionalWhere[self::TABLE] = $pageRepository->enableFields(self::TABLE);
+        $relationHandler->start(
+            '',
+            self::TABLE,
+            '',
+            $uid,
+            'tt_content',
+            BackendUtility::getTcaFieldConfiguration('tt_content', 'tx_listelements_list')
+        );
+        $results = $relationHandler->getFromDB();
+        $results = $results[self::TABLE] ?? [];
+        $items = [];
+        foreach ($relationHandler->tableArray[self::TABLE] ?? [] as $uid) {
+            if (isset($results[$uid])) {
+                $item = $results[$uid];
+                $pageRepository->versionOL(self::TABLE, $item, true);
+                if ($item !== false) {
+                    $items[] = $item;
                 }
             }
-            $items = $this->resortWorkspaceRows($items);
-            return $items;
         }
-        return $rows;
+        return $items;
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -9,7 +9,8 @@ services:
 
   B13\Listelements\Hooks\DrawItem:
     public: true
-
+  B13\Listelements\DataProcessing\ListItemsDataProcessor:
+    public: true
   B13\Listelements\Listener\PageContentPreviewRendering:
     tags:
       - name: event.listener


### PR DESCRIPTION
Workspace sorting did either work in Backend Content Element Preview nor in Frontend Workspace Preview.
For Frontend we ship an new Dataprocessor for listelement items. if you need to use it override TS Settings for you Content Element to

	dataProcessing.1421884800 = B13\Listelements\DataProcessing\ListItemsDataProcessor
	dataProcessing.1421884800.as = listitems

the new DataProcessor will be the default one on next major release.