### PR TITLE
[TASK] Add allowed file types to “images” field

### DIFF
--- a/Configuration/TCA/tx_listelements_item.php
+++ b/Configuration/TCA/tx_listelements_item.php
@@ -163,7 +163,7 @@ return [
                 'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.images.addFileReference',
                 ],
-                'allowed' => 'common-image-types'
+                'allowed' => 'common-image-types',
             ],
         ],
         'assets' => [

--- a/Configuration/TCA/tx_listelements_item.php
+++ b/Configuration/TCA/tx_listelements_item.php
@@ -163,6 +163,7 @@ return [
                 'appearance' => [
                     'createNewRelationLinkTitle' => 'LLL:EXT:listelements/Resources/Private/Language/locallang_db.xlf:tx_listelements_item.images.addFileReference',
                 ],
+                'allowed' => 'common-image-types'
             ],
         ],
         'assets' => [


### PR DESCRIPTION
The field is clearly designated for image formats, so we should by default allow all image types (and only those file types).